### PR TITLE
Add default value when no framework chosen.

### DIFF
--- a/dist/roles-available/nginx/defaults/main.yml
+++ b/dist/roles-available/nginx/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+doc_root: "/home/vagrant/www/project"


### PR DESCRIPTION
I forgot to provide a default value for doc_root when no framework are chosen.
That PR fix that issue.